### PR TITLE
Frameを使ったカードViewの作成

### DIFF
--- a/FrameSample/FrameSample/MainPage.xaml
+++ b/FrameSample/FrameSample/MainPage.xaml
@@ -3,22 +3,21 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="FrameSample.MainPage">
 
-    <StackLayout>
-        <Frame BackgroundColor="#2196F3" Padding="24" CornerRadius="0">
-            <Label Text="Welcome to Xamarin.Forms!" HorizontalTextAlignment="Center" TextColor="White" FontSize="36"/>
+    <StackLayout Padding="12">
+        <Frame
+            BackgroundColor="#78909c"
+            Padding="8"
+            CornerRadius="8"
+            HasShadow="True"
+            HorizontalOptions="Fill"
+            VerticalOptions="CenterAndExpand"
+            >
+            <Label
+                Text="Welcome to Xamarin.Forms!"
+                HorizontalTextAlignment="Center"
+                TextColor="White"
+                FontSize="24"/>
         </Frame>
-        <Label Text="Start developing now" FontSize="Title" Padding="30,10,30,10"/>
-        <Label Text="Make changes to your XAML file and save to see your UI update in the running app with XAML Hot Reload. Give it a try!" FontSize="16" Padding="30,0,30,0"/>
-        <Label FontSize="16" Padding="30,24,30,0">
-            <Label.FormattedText>
-                <FormattedString>
-                    <FormattedString.Spans>
-                        <Span Text="Learn more at "/>
-                        <Span Text="https://aka.ms/xamarin-quickstart" FontAttributes="Bold"/>
-                    </FormattedString.Spans>
-                </FormattedString>
-            </Label.FormattedText>
-        </Label>
     </StackLayout>
 
 </ContentPage>


### PR DESCRIPTION
issue #15 

プロパティ `HasShadow` の動作はプラットフォームに依存する。 default値は、trueですが、影が設定されるのは、iOSだけ。

| ios | andorid |
|:---|:---:|
|<img src="https://user-images.githubusercontent.com/16476224/128148181-1484d36d-4c3e-419d-b255-b2a51161f6be.png" width=320 /> |<img src="https://user-images.githubusercontent.com/16476224/128148379-c4d3f037-86e9-4fe7-bc22-231707a57005.png" width=320 /> |