### PR TITLE
1秒間隔でタイマー処理を実行します（再実行モード）

### DIFF
--- a/TimerSample/TimerSample/MainPage.xaml
+++ b/TimerSample/TimerSample/MainPage.xaml
@@ -3,22 +3,15 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="TimerSample.MainPage">
 
-    <StackLayout>
-        <Frame BackgroundColor="#2196F3" Padding="24" CornerRadius="0">
-            <Label Text="Welcome to Xamarin.Forms!" HorizontalTextAlignment="Center" TextColor="White" FontSize="36"/>
+    <StackLayout Padding="8" HorizontalOptions="Center" VerticalOptions="CenterAndExpand">
+        <Frame BackgroundColor="#ef5350" CornerRadius="12">
+            <Label
+                x:Name="clock"
+                Text="Welcome to zXamarin.Forms!"
+                HorizontalTextAlignment="Center"
+                TextColor="White"
+                FontSize="24"/>
         </Frame>
-        <Label Text="Start developing now" FontSize="Title" Padding="30,10,30,10"/>
-        <Label Text="Make changes to your XAML file and save to see your UI update in the running app with XAML Hot Reload. Give it a try!" FontSize="16" Padding="30,0,30,0"/>
-        <Label FontSize="16" Padding="30,24,30,0">
-            <Label.FormattedText>
-                <FormattedString>
-                    <FormattedString.Spans>
-                        <Span Text="Learn more at "/>
-                        <Span Text="https://aka.ms/xamarin-quickstart" FontAttributes="Bold"/>
-                    </FormattedString.Spans>
-                </FormattedString>
-            </Label.FormattedText>
-        </Label>
     </StackLayout>
 
 </ContentPage>

--- a/TimerSample/TimerSample/MainPage.xaml.cs
+++ b/TimerSample/TimerSample/MainPage.xaml.cs
@@ -10,9 +10,17 @@ namespace TimerSample
 {
     public partial class MainPage : ContentPage
     {
+        // constructor
         public MainPage()
         {
             InitializeComponent();
+            // Start the timer going.
+            Device.StartTimer(TimeSpan.FromSeconds(1), () =>
+            {
+                // Set the Tex property of the Label.
+                clock.Text = DateTime.Now.ToString("HH:mm:ss");
+                return true; // runs again, or false to stop
+            });
         }
     }
 }


### PR DESCRIPTION
issue #22


[Device.StartTimer(TimeSpan, Func<Boolean>) メソッド](https://docs.microsoft.com/ja-jp/dotnet/api/xamarin.forms.device.starttimer?view=xamarin-forms) を使って、定期的なタイマー実装が可能です。

このAPIは、実際の時刻と同期していないので、表示される時刻は同じデバイス上の他の時刻表示とぴったり一致しない。
タイマーの分解能(ティック数)をより細かく設定すれば、正確な時刻表示を表示できる。

## capture

| ios | android |
|:---|:---:|
|<img src="https://user-images.githubusercontent.com/16476224/128300726-793f5ba2-c3ec-4417-9928-723bbdf1c461.gif" width=320 /> |<img src="https://user-images.githubusercontent.com/16476224/128300904-c5235e52-b936-47a7-908e-da430d0f9e07.gif" width=320 /> |

