### PR TITLE
StyleのTargetTypeを基底クラスにすることで汎用的なスタイル作成が可能(適用範囲:ページ単体)

### DIFF
--- a/StyleSample/StyleSample/MainPage.xaml
+++ b/StyleSample/StyleSample/MainPage.xaml
@@ -9,18 +9,18 @@
                 <Setter Property="Padding" Value="36"/>
             </Style>
 
-            <Style x:Key="buttonStyle" TargetType="Button">
+            <Style x:Key="viewStyle" TargetType="View">
                 <Setter Property="HorizontalOptions" Value="Fill"/>
                 <Setter Property="VerticalOptions" Value="CenterAndExpand"/>
-                <Setter Property="Text" Value="set Style text.."/>
                 <Setter Property="BackgroundColor" Value="Chocolate" />
             </Style>
         </ResourceDictionary>
     </ContentPage.Resources>
 
     <StackLayout Style="{StaticResource layoutStyle}">
-        <Button x:Name="button1" Style="{StaticResource buttonStyle}" Text="override text."/>
-        <Button x:Name="button2" Style="{StaticResource buttonStyle}"/>
-        <Button x:Name="button3" Style="{StaticResource buttonStyle}"/>
+        <Button x:Name="button1" Style="{StaticResource viewStyle}" BackgroundColor="AliceBlue" Text="btn1"/>
+        <Button x:Name="button2" Style="{StaticResource viewStyle}" Text="btn2"/>
+        <Button x:Name="button3" Style="{StaticResource viewStyle}" Text="btn3"/>
+        <Label x:Name="label1" Style="{StaticResource viewStyle}" Text="lbl1" HorizontalTextAlignment="Center"/>
     </StackLayout>
 </ContentPage>


### PR DESCRIPTION
issue #40 

| ios | android |
|:---|:---:|
|<img src="https://user-images.githubusercontent.com/16476224/128591699-642cab37-da92-4833-b321-cf85df8a1efc.png" width=320 /> |<img src="https://user-images.githubusercontent.com/16476224/128591712-3d197dfd-9838-4ac7-9ffe-15a2d9be0c58.png" width=320 /> |