### PR TITLE
暗黙的なStyle指定(適用範囲:ページ単体)

### DIFF
--- a/StyleSample/StyleSample/MainPage.xaml
+++ b/StyleSample/StyleSample/MainPage.xaml
@@ -5,22 +5,26 @@
 
     <ContentPage.Resources>
         <ResourceDictionary>
-            <Style x:Key="layoutStyle" TargetType="StackLayout">
+            <Style TargetType="StackLayout">
                 <Setter Property="Padding" Value="36"/>
             </Style>
 
-            <Style x:Key="viewStyle" TargetType="View">
+            <Style TargetType="Button">
                 <Setter Property="HorizontalOptions" Value="Fill"/>
                 <Setter Property="VerticalOptions" Value="CenterAndExpand"/>
+                <Setter Property="BackgroundColor" Value="Chocolate" />
+            </Style>
+            <Style TargetType="Label">
+                <Setter Property="HorizontalTextAlignment" Value="Center"/>
                 <Setter Property="BackgroundColor" Value="Chocolate" />
             </Style>
         </ResourceDictionary>
     </ContentPage.Resources>
 
-    <StackLayout Style="{StaticResource layoutStyle}">
-        <Button x:Name="button1" Style="{StaticResource viewStyle}" BackgroundColor="AliceBlue" Text="btn1"/>
-        <Button x:Name="button2" Style="{StaticResource viewStyle}" Text="btn2"/>
-        <Button x:Name="button3" Style="{StaticResource viewStyle}" Text="btn3"/>
-        <Label x:Name="label1" Style="{StaticResource viewStyle}" Text="lbl1" HorizontalTextAlignment="Center"/>
+    <StackLayout>
+        <Button x:Name="button1" BackgroundColor="AliceBlue" Text="btn1"/>
+        <Button x:Name="button2"  Text="btn2"/>
+        <Button x:Name="button3"  Text="btn3"/>
+        <Label x:Name="label1"  Text="lbl1"/>
     </StackLayout>
 </ContentPage>


### PR DESCRIPTION
issue #40 

## 実装メモ
- **乱用すると可読性悪くなるので注意！**
- `x:Key`を指定しなくても`Dictionary Key`は自動生成される。生成されたキーは特殊で、`StaticResource`で直接参照できない。
- `ResourceDictionary`に含まれている`Style`のうち、こうした自動生成キーを持つものを**暗黙的なスタイル**と呼ぶ。
- `ResourceDictionary`スコープ内の要素の型がこのDictionary Keyと同じで、かつその要素のStyleプロパティに別のStyleオブジェクトが明示的に設定されていない場合、この暗黙的なスタイルは自動的に適用される。

## capture

| ios | android |
|:---|:---:|
|<img src="https://user-images.githubusercontent.com/16476224/128591917-b1d826b7-fad0-4a8b-a365-289e64ba314e.png" width=320 /> |<img src="https://user-images.githubusercontent.com/16476224/128591905-2715fe74-f2a3-4882-a6bb-9b43f27a4b42.png" width=320 /> |