### PR TITLE
sample for bitmap FromUri

### DIFF
--- a/BitmapSample/BitmapSample/MainPage.xaml
+++ b/BitmapSample/BitmapSample/MainPage.xaml
@@ -3,22 +3,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="BitmapSample.MainPage">
 
-    <StackLayout>
-        <Frame BackgroundColor="#2196F3" Padding="24" CornerRadius="0">
-            <Label Text="Welcome to Xamarin.Forms!" HorizontalTextAlignment="Center" TextColor="White" FontSize="36"/>
-        </Frame>
-        <Label Text="Start developing now" FontSize="Title" Padding="30,10,30,10"/>
-        <Label Text="Make changes to your XAML file and save to see your UI update in the running app with XAML Hot Reload. Give it a try!" FontSize="16" Padding="30,0,30,0"/>
-        <Label FontSize="16" Padding="30,24,30,0">
-            <Label.FormattedText>
-                <FormattedString>
-                    <FormattedString.Spans>
-                        <Span Text="Learn more at "/>
-                        <Span Text="https://aka.ms/xamarin-quickstart" FontAttributes="Bold"/>
-                    </FormattedString.Spans>
-                </FormattedString>
-            </Label.FormattedText>
-        </Label>
+    <StackLayout Padding="50" HorizontalOptions="Center" VerticalOptions="CenterAndExpand">
+        <Label Text="sample for bitmap FromUri" Style="{DynamicResource TitleStyle}"/>
+        <Image Source="https://assets.pokemon.com/assets/cms2/img/pokedex/full/500.png" />
+        <Image Source="https://source.unsplash.com/random/400x400"/>
     </StackLayout>
 
 </ContentPage>


### PR DESCRIPTION
issue #50 

web経由のイメージ取得時のキャッシュの挙動は以下にまとめています。
https://github.com/LeoAndo/xamarin-forms-traning/issues/50#issuecomment-896676023

| ios | android |
|:---|:---:|
|<img src="https://user-images.githubusercontent.com/16476224/129008837-41e38107-f052-4677-8754-a3a2d881d203.png" width=320 /> |<img src="https://user-images.githubusercontent.com/16476224/129009179-72345449-b38b-429d-8133-a7f3997d63f6.png" width=320 /> |