### PR TITLE
Xamlでdatabinding定義を行うサンプル

### DIFF
--- a/DataBindingSample/DataBindingSample/App.xaml.cs
+++ b/DataBindingSample/DataBindingSample/App.xaml.cs
@@ -10,7 +10,8 @@ namespace DataBindingSample
         {
             InitializeComponent();
 
-            MainPage = new MainPage();
+            // MainPage = new MainPage();
+            MainPage = new Sample2Page();
         }
 
         protected override void OnStart()

--- a/DataBindingSample/DataBindingSample/Sample2Page.xaml
+++ b/DataBindingSample/DataBindingSample/Sample2Page.xaml
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="DataBindingSample.Sample2Page">
+    <!--Xamlでdatabinding定義を行うサンプル-->
+    <StackLayout
+        Padding="40"
+        VerticalOptions="CenterAndExpand">
+        <Label
+            x:Name="label"
+            Text="Opacity Binding Demo"
+            HorizontalOptions="Center"
+            Style="{DynamicResource TitleStyle}"
+            BindingContext="{x:Reference Name=slider}"
+            Opacity="{Binding Path=Value}"/>
+        <Slider x:Name="slider"/>
+    </StackLayout>
+
+</ContentPage>

--- a/DataBindingSample/DataBindingSample/Sample2Page.xaml.cs
+++ b/DataBindingSample/DataBindingSample/Sample2Page.xaml.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Xamarin.Forms;
+
+namespace DataBindingSample
+{
+    public partial class Sample2Page : ContentPage
+    {
+        public Sample2Page()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
issue #59 

Sliderのvalueプロパティをソース、LabelのOpacityプロパティをターゲットにdatabindingを定義.

| ios | android |
|:---|:---:|
|<img src="https://user-images.githubusercontent.com/16476224/129333898-05befcb4-da08-4437-88b5-c2d7f47b6cb2.gif" width=320 /> |<img src="https://user-images.githubusercontent.com/16476224/129333768-e42f0b0d-9105-4e49-a71d-295618af758e.gif" width=320 /> |