### PR TITLE
ios UseSafeArea Trueの設定

### DIFF
--- a/UseSafeAreaSample/UseSafeAreaSample/MainPage.xaml
+++ b/UseSafeAreaSample/UseSafeAreaSample/MainPage.xaml
@@ -1,7 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="UseSafeAreaSample.MainPage">
+             x:Class="UseSafeAreaSample.MainPage"
+             xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
+             ios:Page.UseSafeArea="True">
 
     <StackLayout>
         <Frame BackgroundColor="#2196F3" Padding="24" CornerRadius="0">


### PR DESCRIPTION
issue #11 

# capture iOS

| before | after |
|:---|:---:|
|<img src="https://user-images.githubusercontent.com/16476224/136644435-62bb948b-5d25-493a-97a6-14efa657e8d6.png" width=320 /> |<img src="https://user-images.githubusercontent.com/16476224/136644441-5c4ff4cf-e0b8-46b9-a0ba-aeb76a6be842.png" width=320 /> |

# capture Android

`ios:Page.UseSafeArea="True"` を設定によるAndroid側の影響はない。

<img src="https://user-images.githubusercontent.com/16476224/136644483-7c92f785-0d12-4eb8-b977-bcf81c071654.png" width=320 />